### PR TITLE
Dev keyboard merge into main

### DIFF
--- a/player/input_wrappers/keyboard.py
+++ b/player/input_wrappers/keyboard.py
@@ -18,8 +18,23 @@ class KeyboardWrapper(BaseInputWrapper):
             ")": "shift+0",
         }
 
-    def send_key(self, key):
-        pass
+    def __solve_code(self, key):
+        if len(key) != 1:
+            raise Exception("Invalid key length")
 
-    def send_chord(self, key):
-        pass
+        if key in self.__specialUpperKeys:
+            return self.__specialUpperKeys[key]
+        elif key.isalnum():
+            if key.isupper():
+                code = "shift+" + key.lower()
+                return code
+            else:
+                return key
+
+    def send_key(self, key):
+        code = self.__solve_code(key)
+        keyboard.send(code)
+
+    def send_chord(self, chord):
+        for key in chord:
+            self.send_key(key)

--- a/player/input_wrappers/keyboard.py
+++ b/player/input_wrappers/keyboard.py
@@ -1,0 +1,25 @@
+import keyboard
+from base import BaseInputWrapper
+
+class KeyboardWrapper(BaseInputWrapper):
+
+    def __init__(self):
+        BaseInputWrapper.__init__(self)
+        self.__specialUpperKeys = {
+            "!": "shift+1",
+            "@": "shift+2",
+            "#": "shift+3",
+            "$": "shift+4",
+            "%": "shift+5",
+            "^": "shift+6",
+            "&": "shift+7",
+            "*": "shift+8",
+            "(": "shift+9",
+            ")": "shift+0",
+        }
+
+    def send_key(self, key):
+        pass
+
+    def send_chord(self, key):
+        pass

--- a/player/input_wrappers/keyboard.py
+++ b/player/input_wrappers/keyboard.py
@@ -8,14 +8,11 @@ class KeyboardWrapper(BaseInputWrapper):
         self.__specialUpperKeys = {
             "!": "shift+1",
             "@": "shift+2",
-            "#": "shift+3",
             "$": "shift+4",
             "%": "shift+5",
             "^": "shift+6",
-            "&": "shift+7",
             "*": "shift+8",
-            "(": "shift+9",
-            ")": "shift+0",
+            "(": "shift+9"
         }
 
     def __solve_code(self, key):


### PR DESCRIPTION
Defined and implemented the KeyboardWrapper class in keyboard.py, which extends upon BaseInputWrapper class and uses "keyboard" Python library to send inputs (compatible with Windows).
This implementation avoids some keys which are obsolete in the context of Virtual Piano players, such as "#" ("shift+3") which doesn't correspond to any black key. However, most upper keys which do not have a corresponding black key, specifically the upper alphabetic keys, are still processed and sent.

**Requires testing.**